### PR TITLE
Add abstraction layer for the client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ tracing-subscriber = "0.3"
 
 [dependencies.kyoto]
 git = "https://github.com/rustaceanrob/kyoto"
-branch = "master"
+rev = "526a8dcf88bbce8c029426b45cbd941700ad1aa2"
 
 [dependencies.bdk_wallet]
 # version alpha.13

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -55,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
 
     let builder = NodeBuilder::new(Network::Signet);
     let (mut node, client) = builder
-        .add_peers(peers.into_iter().map(|ip| (ip, 38333)).collect())
+        .add_peers(peers.into_iter().map(|ip| (ip, None).into()).collect())
         .add_scripts(spks_to_watch)
         .anchor_checkpoint(HeaderCheckpoint::new(
             169_000,

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -77,7 +77,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Sync and apply updates
-    if let Some(update) = client.sync().await {
+    if let Some(update) = client.update().await {
         let bdk_kyoto::Update {
             cp,
             indexed_tx_graph,

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
                 last_active_indices: indexed_tx_graph.index.last_used_indices(),
             })?;
             // Do something here to add more scripts?
-
+            
             let cp = wallet.latest_checkpoint();
             tracing::info!("Tx count: {}", wallet.transactions().count());
             tracing::info!("Balance: {}", wallet.balance().total().to_sat());

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -15,14 +15,13 @@ use bdk_wallet::{
 
 use kyoto::chain::checkpoints::{HeaderCheckpoint, SIGNET_HEADER_CP};
 use kyoto::node::builder::NodeBuilder;
+use kyoto::TrustedPeer;
 
 /// Peer address whitelist
 const PEERS: &[IpAddr] = &[
     IpAddr::V4(Ipv4Addr::new(170, 75, 163, 219)),
     IpAddr::V4(Ipv4Addr::new(23, 137, 57, 100)),
 ];
-/// Bitcoin P2P port
-const PORT: u16 = 38333;
 
 /* Sync a bdk wallet */
 
@@ -41,8 +40,10 @@ async fn main() -> anyhow::Result<()> {
         hash: BlockHash::from_str(hash).unwrap(),
     });
 
-    // Need to fix this on the Kyoto side. Port should be optional and this should be a struct
-    let peers = PEERS.into_iter().map(|ip| Peer(*ip, PORT)).collect();
+    let peers = PEERS
+        .into_iter()
+        .map(|ip| TrustedPeer::new(*ip, None))
+        .collect();
 
     let mut wallet = Wallet::new(desc, change_desc, Network::Signet)?;
 

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -4,102 +4,84 @@ use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
+use bdk_kyoto::builder::{LightClientBuilder, Peer};
 use bdk_wallet::bitcoin::{BlockHash, Network, ScriptBuf};
 use bdk_wallet::{
     wallet::{self, Wallet},
     KeychainKind,
 };
 
-use kyoto::chain::checkpoints::HeaderCheckpoint;
+use kyoto::chain::checkpoints::{HeaderCheckpoint, SIGNET_HEADER_CP};
 use kyoto::node::builder::NodeBuilder;
 
 /* Sync a bdk wallet */
 
-// Highest derivation index to include in the sync
-const TARGET_INDEX: u32 = 19;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/0/*)";
-    let change_desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/1/*)";
-
-    let mut wallet = Wallet::new(desc, change_desc, Network::Signet)?;
-
-    println!(
-        "Balance before sync: {} sats",
-        wallet.balance().total().to_sat()
-    );
-
-    // Populate the list of watched script pubkeys
-    let mut spks: HashSet<ScriptBuf> = HashSet::new();
-    for keychain in [KeychainKind::External, KeychainKind::Internal] {
-        for index in 0..=TARGET_INDEX {
-            spks.insert(wallet.peek_address(keychain, index).script_pubkey());
-        }
-    }
-
-    // Set a wallet birthday
-    let header_cp = HeaderCheckpoint::new(
-        169_000,
-        BlockHash::from_str("000000ed6fe89c46140f55ff511c558bcbdb1239ba95474f38f619b3bb657d4a")?,
-    );
-
-    // Configure kyoto node and console logger
     let subscriber = tracing_subscriber::FmtSubscriber::new();
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
+    let desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/0/*)";
+    let change_desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/1/*)";
+
+    // We can use a predefined header if we don't have one
+    let (height, hash) = SIGNET_HEADER_CP.into_iter().rev().nth(3).unwrap();
+    let header_cp = HeaderCheckpoint::new(*height, BlockHash::from_str(&hash).unwrap());
+
+    // Need to fix this on the Kyoto side. Port should be optional and this should be a struct
     let port = 38333;
     let peers = vec![
         IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         IpAddr::V4(Ipv4Addr::new(170, 75, 163, 219)),
         IpAddr::V4(Ipv4Addr::new(23, 137, 57, 100)),
     ];
-    let builder = NodeBuilder::new(Network::Signet);
-    let (mut node, client) = builder
-        .add_peers(peers.into_iter().map(|ip| (ip, port)).collect())
-        .add_scripts(spks)
-        .anchor_checkpoint(header_cp)
-        .num_required_peers(2)
-        .build_node()
+    let peers = peers.into_iter().map(|ip| Peer(ip, port)).collect();
+
+    let mut wallet = Wallet::new(desc, change_desc, Network::Signet)?;
+
+    // The light client builder handles the logic of inserting the SPKs
+    let (node, mut client) = LightClientBuilder::new(&wallet)
+        .add_birthday(header_cp)
+        .add_peers(peers)
+        .build()
         .await;
 
-    // Start a sync request
-    let req = bdk_kyoto::Request::new(wallet.local_chain().tip(), wallet.spk_index());
-    let mut client = req.into_client(client);
-
-    // Run the node
-    if !node.is_running() {
-        tokio::task::spawn(async move { node.run().await });
-    }
-
-    // Sync and apply updates
-    if let Some(update) = client.sync().await {
-        let bdk_kyoto::Update {
-            cp,
-            indexed_tx_graph,
-        } = update;
-
-        wallet.apply_update(wallet::Update {
-            chain: Some(cp),
-            graph: indexed_tx_graph.graph().clone(),
-            last_active_indices: indexed_tx_graph.index.last_used_indices(),
-        })?;
-    }
-
-    let _ = client.shutdown().await?;
-
-    let cp = wallet.latest_checkpoint();
-    println!("Synced to tip: {} {}", cp.height(), cp.hash());
-    println!("Tx count: {}", wallet.transactions().count());
-    println!("Balance: {:#?}", wallet.balance());
-    println!(
-        "Last revealed External: {}",
-        wallet.derivation_index(KeychainKind::External).unwrap()
+    tracing::info!(
+        "Balance before sync: {} sats",
+        wallet.balance().total().to_sat()
     );
-    println!(
-        "Last revealed Internal: {}",
-        wallet.derivation_index(KeychainKind::Internal).unwrap()
-    );
+
+    client.run_node(node);
+
+    // Sync and apply updates. We can do this a continual loop while the "application" is running.
+    // Often this loop would be on a separate "Task" in a Swift app for instance
+    loop {
+        if let Some(update) = client.update().await {
+            let bdk_kyoto::Update {
+                cp,
+                indexed_tx_graph,
+            } = update;
+
+            wallet.apply_update(wallet::Update {
+                chain: Some(cp),
+                graph: indexed_tx_graph.graph().clone(),
+                last_active_indices: indexed_tx_graph.index.last_used_indices(),
+            })?;
+            // Do something here to add more scripts?
+
+            let cp = wallet.latest_checkpoint();
+            tracing::info!("Tx count: {}", wallet.transactions().count());
+            tracing::info!("Balance: {}", wallet.balance().total().to_sat());
+            tracing::info!(
+                "Last revealed External: {}",
+                wallet.derivation_index(KeychainKind::External).unwrap()
+            );
+            tracing::info!(
+                "Last revealed Internal: {}",
+                wallet.derivation_index(KeychainKind::Internal).unwrap()
+            );
+        }
+    }
 
     Ok(())
 }

--- a/src/bin/example_kyoto.rs
+++ b/src/bin/example_kyoto.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
             if let Some(bdk_kyoto::Update {
                 cp,
                 indexed_tx_graph,
-            }) = client.sync().await
+            }) = client.update().await
             {
                 let mut chain = chain.lock().unwrap();
                 let mut graph = graph.lock().unwrap();

--- a/src/bin/example_kyoto.rs
+++ b/src/bin/example_kyoto.rs
@@ -142,7 +142,13 @@ async fn main() -> anyhow::Result<()> {
             // Configure kyoto node
             let builder = NodeBuilder::new(Network::Signet);
             let (mut node, client) = builder
-                .add_peers(PEERS.iter().cloned().map(|ip| (ip, PORT)).collect())
+                .add_peers(
+                    PEERS
+                        .iter()
+                        .cloned()
+                        .map(|ip| (ip, Some(PORT)).into())
+                        .collect(),
+                )
                 .add_scripts(spks)
                 .anchor_checkpoint(header_cp)
                 .num_required_peers(2)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,99 @@
+//! [`bdk_kyoto::Client`] builder
+
+use std::{collections::HashSet, net::IpAddr};
+
+use bdk_wallet::{
+    chain::{local_chain::CheckPoint, BlockId},
+    KeychainKind, Wallet,
+};
+use kyoto::{
+    chain::checkpoints::HeaderCheckpoint,
+    node::{builder::NodeBuilder, node::Node},
+    ScriptBuf,
+};
+
+use crate::{Client, Request};
+
+// There is very little cost to doing a lookahead this generous.
+// By doing so, a user can reveal many scripts without ever having
+// to add them on the fly to the node.
+const TARGET_INDEX: u32 = 100;
+
+#[derive(Debug)]
+/// Construct a light client from higher level components.
+pub struct LightClientBuilder<'a> {
+    wallet: &'a Wallet,
+    peers: Option<Vec<Peer>>,
+    required_peers: Option<u8>,
+    birthday: Option<CheckPoint>,
+}
+
+impl<'a> LightClientBuilder<'a> {
+    /// Construct a new node builder
+    pub fn new(wallet: &'a Wallet) -> Self {
+        Self {
+            wallet,
+            peers: None,
+            required_peers: None,
+            birthday: None,
+        }
+    }
+
+    /// Add a wallet "birthday", or block to start searching for transactions _strictly after_.
+    pub fn add_birthday(mut self, birthday: HeaderCheckpoint) -> Self {
+        self.birthday = Some(CheckPoint::new(BlockId {
+            height: birthday.height,
+            hash: birthday.hash,
+        }));
+        self
+    }
+
+    /// Add peers to connect to over the P2P network.
+    pub fn add_peers(mut self, peers: Vec<Peer>) -> Self {
+        self.peers = Some(peers);
+        self
+    }
+
+    /// Build a light client node and a client to interact with the node
+    pub async fn build(self) -> (Node, Client<KeychainKind>) {
+        let mut node_builder = NodeBuilder::new(self.wallet.network());
+        if let Some(whitelist) = self.peers {
+            let peers = whitelist.iter().map(|peer| (peer.0, peer.1)).collect();
+            node_builder = node_builder.add_peers(peers);
+        }
+        match self.birthday {
+            Some(birthday) => {
+                if birthday.height() < self.wallet.local_chain().tip().height() {
+                    let block_id = self.wallet.local_chain().tip();
+                    let header_cp = HeaderCheckpoint::new(block_id.height(), block_id.hash());
+                    node_builder = node_builder.anchor_checkpoint(header_cp)
+                } else {
+                    node_builder = node_builder.anchor_checkpoint(HeaderCheckpoint::new(
+                        birthday.height(),
+                        birthday.hash(),
+                    ))
+                }
+            }
+            None => {
+                let block_id = self.wallet.local_chain().tip();
+                let header_cp = HeaderCheckpoint::new(block_id.height(), block_id.hash());
+                node_builder = node_builder.anchor_checkpoint(header_cp)
+            }
+        }
+        node_builder = node_builder.num_required_peers(self.required_peers.unwrap_or(2));
+        let mut spks: HashSet<ScriptBuf> = HashSet::new();
+        for keychain in [KeychainKind::External, KeychainKind::Internal] {
+            for index in 0..=TARGET_INDEX {
+                spks.insert(self.wallet.peek_address(keychain, index).script_pubkey());
+            }
+        }
+        let (node, kyoto_client) = node_builder.add_scripts(spks).build_node().await;
+        let request = Request::new(self.wallet.local_chain().tip(), self.wallet.spk_index());
+        let client = request.into_client(kyoto_client);
+        (node, client)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+/// A peer to connect to on the Bitcoin P2P network
+pub struct Peer(pub IpAddr, pub u16);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,11 +40,8 @@ impl<'a> LightClientBuilder<'a> {
     }
 
     /// Add a wallet "birthday", or block to start searching for transactions _strictly after_.
-    pub fn add_birthday(mut self, birthday: HeaderCheckpoint) -> Self {
-        self.birthday = Some(CheckPoint::new(BlockId {
-            height: birthday.height,
-            hash: birthday.hash,
-        }));
+    pub fn add_birthday(mut self, birthday: CheckPoint) -> Self {
+        self.birthday = Some(birthday);
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use bdk_wallet::{
 use kyoto::{
     chain::checkpoints::HeaderCheckpoint,
     node::{builder::NodeBuilder, node::Node},
-    ScriptBuf,
+    ScriptBuf, TrustedPeer,
 };
 
 use crate::{Client, Request};
@@ -23,7 +23,7 @@ const TARGET_INDEX: u32 = 100;
 /// Construct a light client from higher level components.
 pub struct LightClientBuilder<'a> {
     wallet: &'a Wallet,
-    peers: Option<Vec<Peer>>,
+    peers: Option<Vec<TrustedPeer>>,
     required_peers: Option<u8>,
     birthday: Option<CheckPoint>,
 }
@@ -46,7 +46,7 @@ impl<'a> LightClientBuilder<'a> {
     }
 
     /// Add peers to connect to over the P2P network.
-    pub fn add_peers(mut self, peers: Vec<Peer>) -> Self {
+    pub fn add_peers(mut self, peers: Vec<TrustedPeer>) -> Self {
         self.peers = Some(peers);
         self
     }
@@ -55,8 +55,7 @@ impl<'a> LightClientBuilder<'a> {
     pub async fn build(self) -> (Node, Client<KeychainKind>) {
         let mut node_builder = NodeBuilder::new(self.wallet.network());
         if let Some(whitelist) = self.peers {
-            let peers = whitelist.iter().map(|peer| (peer.0, peer.1)).collect();
-            node_builder = node_builder.add_peers(peers);
+            node_builder = node_builder.add_peers(whitelist);
         }
         match self.birthday {
             Some(birthday) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,10 @@
 use bdk_wallet::KeychainKind;
 use core::fmt;
 use core::mem;
-use kyoto::node::messages::SyncUpdate;
-use kyoto::node::node::Node;
-use kyoto::ScriptBuf;
+pub use kyoto::node::messages::SyncUpdate;
+pub use kyoto::ScriptBuf;
 use std::collections::HashSet;
-use tokio::sync::broadcast;
+pub use tokio::sync::broadcast;
 
 use bdk_wallet::bitcoin::{BlockHash, Transaction};
 
@@ -21,9 +20,11 @@ use bdk_wallet::chain::{
     BlockId, ConfirmationTimeHeightAnchor, IndexedTxGraph,
 };
 
-use kyoto::node::{self, messages::NodeMessage};
-use kyoto::IndexedBlock;
-use kyoto::TxBroadcast;
+pub use kyoto::node::{self, messages::NodeMessage};
+pub use kyoto::IndexedBlock;
+pub use kyoto::TxBroadcast;
+pub use kyoto::TrustedPeer;
+pub use kyoto::node::node::Node;
 
 pub mod builder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ where
 
     /// Run a node continuously in the background
     pub fn run_node(&self, mut node: Node) {
-        let _ = tokio::task::spawn(async move { node.run().await });
+        tokio::task::spawn(async move { node.run().await });
     }
 
     /// Shutdown.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,13 @@ where
                 }
                 NodeMessage::TxSent(_) => {}
                 NodeMessage::TxBroadcastFailure(_) => {}
-                NodeMessage::Dialog(s) => tracing::info!("{s}"),
-                NodeMessage::Warning(s) => tracing::warn!("{s}"),
+                NodeMessage::Dialog(s) => { 
+                    println!("{s}");
+                    tracing::info!("{s}") 
+                } ,
+                NodeMessage::Warning(s) => { 
+                    println!("{s}");
+                    tracing::warn!("{s}") },
             }
         }
 


### PR DESCRIPTION
In thinking about thunder's comments, this is what I drew up. Small thing, but I changed the `sync` method to `update` here to reflect what is being returned, and also to allude to the fact that this may be called throughout the lifetime of the application running. I also made a `LightClientBuilder` structure that takes a reference to the wallet. In doing so the node can be built internally by using the SPK index and the `LocalChain` tip. You'll see in the wallet example this greatly reduces the code down and makes it easier to understand what is going on. I also added a simple convenience method on the client to run the node with a new task.  Might be important to note, this abstraction mostly be for BDK and BDK FFI, as the LDK node implementation would still work with `Request` and `Client<K>`. No big deal though, as they maintain their own bindings anyway and this stuff should still be abstracted away to end user devs.

Note that `examples/wallet.rs` now runs forever and listens for new blocks. `Crtl + C` to kill it