### PR TITLE
make a new constructor, use FullScanResult

### DIFF
--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -33,7 +33,6 @@ async fn main() -> anyhow::Result<()> {
     let desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/0/*)";
     let change_desc = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/1/*)";
 
-    // We can use a predefined header if we don't have one. We use 170_000 here
     let (height, hash) = SIGNET_HEADER_CP.into_iter().rev().nth(3).unwrap();
     let header_cp = CheckPoint::new(BlockId {
         height: *height,
@@ -42,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
 
     let peers = PEERS
         .into_iter()
-        .map(|ip| TrustedPeer::new(*ip, None))
+        .map(|ip| TrustedPeer::from_ip(*ip))
         .collect();
 
     let mut wallet = Wallet::new(desc, change_desc, Network::Signet)?;
@@ -66,7 +65,6 @@ async fn main() -> anyhow::Result<()> {
         if let Some(update) = client.update().await {
             wallet.apply_update(update)?;
             // Do something here to add more scripts?
-            let cp = wallet.latest_checkpoint();
             tracing::info!("Tx count: {}", wallet.transactions().count());
             tracing::info!("Balance: {}", wallet.balance().total().to_sat());
             tracing::info!(

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -64,18 +64,8 @@ async fn main() -> anyhow::Result<()> {
     // Often this loop would be on a separate "Task" in a Swift app for instance
     loop {
         if let Some(update) = client.update().await {
-            let bdk_kyoto::Update {
-                cp,
-                indexed_tx_graph,
-            } = update;
-
-            wallet.apply_update(wallet::Update {
-                chain: Some(cp),
-                graph: indexed_tx_graph.graph().clone(),
-                last_active_indices: indexed_tx_graph.index.last_used_indices(),
-            })?;
+            wallet.apply_update(update)?;
             // Do something here to add more scripts?
-
             let cp = wallet.latest_checkpoint();
             tracing::info!("Tx count: {}", wallet.transactions().count());
             tracing::info!("Balance: {}", wallet.balance().total().to_sat());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -84,7 +84,11 @@ impl<'a> LightClientBuilder<'a> {
             }
         }
         let (node, kyoto_client) = node_builder.add_scripts(spks).build_node();
-        let request = Request::new(self.wallet.local_chain().tip(), self.wallet.spk_index());
-        (node, Client::from_request(request, kyoto_client))
+        let client = Client::from_index(
+            self.wallet.local_chain().tip(),
+            self.wallet.spk_index(),
+            kyoto_client,
+        );
+        (node, client)
     }
 }


### PR DESCRIPTION
with the way things have evolved, im thinking of just constructing the `Client` with a direct constructor instead of using the request flow. let me know what you think there, i added the constructor in this PR. signet example also uses it. depending on how `bdk_chain` stuff evolves or if we get any clever ideas we may also construct the `Client` directly from a `FullScanRequest`. i also use `FullScanResult` as the return type of `update` within the `Option<T>`. that way we can just apply the update directly to the wallet or the user can extract whatever fields they want