### PR TITLE
bump bdk_wallet and test kyoto dns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ tracing-subscriber = { version = "0.3", optional = true }
 
 [dependencies.kyoto]
 git = "https://github.com/rustaceanrob/kyoto"
-rev = "03a3fad658987b74359a523a14015d883d130337"
+rev = "391bc1a1e921bbdf9f0cce58b115572b00b29146"
 
 [dependencies.bdk_wallet]
-version = "1.0.0-alpha.13"
+version = "1.0.0-beta.1"
 
 [features]
 default = ["trace"]

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 use std::sync::Arc;
+use bdk_wallet::chain::Merge;
 use tokio::task;
 
 use bdk_kyoto::logger::PrintLogger;
@@ -10,8 +11,8 @@ use bdk_wallet::bitcoin::{
     constants::genesis_block, secp256k1::Secp256k1, Address, BlockHash, Network, ScriptBuf,
 };
 use bdk_wallet::chain::{
-    keychain::KeychainTxOutIndex, local_chain::LocalChain, miniscript::Descriptor,
-    spk_client::FullScanResult, Append, FullTxOut, IndexedTxGraph, SpkIterator,
+    keychain_txout::KeychainTxOutIndex, local_chain::LocalChain, miniscript::Descriptor,
+    spk_client::FullScanResult, FullTxOut, IndexedTxGraph, SpkIterator,
 };
 use kyoto::chain::checkpoints::HeaderCheckpoint;
 use kyoto::node::builder::NodeBuilder;
@@ -84,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
 
         let mut indexed_tx_graph_changeset = graph.apply_update(graph_update);
         let index_changeset = graph.index.reveal_to_target_multi(&last_active_indices);
-        indexed_tx_graph_changeset.append(index_changeset.into());
+        indexed_tx_graph_changeset.merge(index_changeset.into());
         let _ = graph.apply_changeset(indexed_tx_graph_changeset);
     }
 

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bdk_kyoto::builder::LightClientBuilder;
 use bdk_kyoto::logger::TraceLogger;
 use bdk_wallet::bitcoin::Network;
-use bdk_wallet::{wallet::Wallet, KeychainKind};
+use bdk_wallet::{KeychainKind, Wallet};
 use kyoto::TrustedPeer;
 
 /// Peer address whitelist
@@ -25,7 +25,9 @@ async fn main() -> anyhow::Result<()> {
         .map(|ip| TrustedPeer::from_ip(*ip))
         .collect();
 
-    let mut wallet = Wallet::new(desc, change_desc, Network::Signet)?;
+    let mut wallet = Wallet::create(desc, change_desc)
+        .network(Network::Signet)
+        .create_wallet_no_persist()?;
 
     // The light client builder handles the logic of inserting the SPKs
     let (mut node, mut client) = LightClientBuilder::new(&wallet)

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -144,7 +144,7 @@ impl<'a> LightClientBuilder<'a> {
             for index in 0..=self
                 .wallet
                 .spk_index()
-                .last_revealed_index(&keychain)
+                .last_revealed_index(keychain)
                 .unwrap_or(0)
                 + TARGET_INDEX
             {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -47,7 +47,7 @@ impl NodeMessageHandler for PrintLogger {
     }
 
     fn handle_state_changed(&self, state: NodeState) {
-        println!("State change: {state:?}")
+        println!("State change: {state}")
     }
 
     fn handle_tx_sent(&self) {
@@ -89,7 +89,7 @@ impl NodeMessageHandler for TraceLogger {
     }
 
     fn handle_state_changed(&self, state: NodeState) {
-        tracing::info!("State change: {state:?}")
+        tracing::info!("State change: {state}")
     }
 
     fn handle_tx_sent(&self) {


### PR DESCRIPTION
bumps to `beta.1`. for whatever reason when i had `alpha.13` in my `Cargo.toml` the compiler still insisted on using `beta.1`. i did a `cargo clean` and it still built `beta.` so i went ahead and upgraded. also tested new DNS in kyoto