### PR TITLE
lib: update kyoto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 
-[dependencies.kyoto]
+[dependencies.kyoto-cbf]
 git = "https://github.com/rustaceanrob/kyoto"
-rev = "3ac764e52c361a5fec61f151b0e21cf2dd0326d2"
+rev = "450f1e1526d2e30608e12f94d7c528accedc727e"
 
 [dependencies.bdk_wallet]
 version = "1.0.0-beta.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,24 +19,19 @@ use crate::logger::NodeMessageHandler;
 
 pub mod builder;
 pub mod logger;
-
+pub use kyoto::node::error::ClientError;
 pub use kyoto::{
-    node::{
-        self,
-        client::{self, Receiver},
-        messages::{NodeMessage, SyncUpdate},
-        node::Node,
-    },
-    IndexedBlock, TrustedPeer, TxBroadcast, TxBroadcastPolicy,
+    ClientSender, IndexedBlock, Node, NodeMessage, Receiver, SyncUpdate, TrustedPeer, TxBroadcast,
+    TxBroadcastPolicy,
 };
 
-/// Client.
+/// A compact block filter client.
 #[derive(Debug)]
 pub struct Client<K> {
     // channel sender
-    sender: client::ClientSender,
+    sender: kyoto::ClientSender,
     // channel receiver
-    receiver: kyoto::node::client::Receiver<NodeMessage>,
+    receiver: kyoto::Receiver<NodeMessage>,
     // changes to local chain
     chain: local_chain::LocalChain,
     // receive graph
@@ -53,7 +48,7 @@ where
     pub fn from_index(
         cp: CheckPoint,
         index: &KeychainTxOutIndex<K>,
-        client: client::Client,
+        client: kyoto::Client,
     ) -> Self {
         let (sender, receiver) = client.split();
         Self {
@@ -188,12 +183,12 @@ where
 /// Type that broadcasts transactions to the network.
 #[derive(Debug)]
 pub struct TransactionBroadcaster {
-    sender: client::ClientSender,
+    sender: kyoto::ClientSender,
 }
 
 impl TransactionBroadcaster {
     /// Create a new transaction broadcaster with the given client `sender`.
-    fn new(sender: client::ClientSender) -> Self {
+    fn new(sender: kyoto::ClientSender) -> Self {
         Self { sender }
     }
 
@@ -217,7 +212,7 @@ impl TransactionBroadcaster {
 #[derive(Debug)]
 pub enum Error {
     /// The channel to receive a message was closed. Likely the node has stopped running.
-    Sender(node::error::ClientError),
+    Sender(ClientError),
 }
 
 impl core::fmt::Display for Error {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -2,8 +2,8 @@
 
 use std::fmt::Debug;
 
-pub use kyoto::node::messages::Warning;
-pub use kyoto::node::node::NodeState;
+pub use kyoto::Warning;
+pub use kyoto::NodeState;
 pub use kyoto::Txid;
 
 /// Handle dialog and state changes from a node with some arbitrary behavior.
@@ -14,7 +14,7 @@ pub use kyoto::Txid;
 pub trait NodeMessageHandler: Send + Sync + Debug + 'static {
     /// Make use of some message the node has sent.
     fn handle_dialog(&self, dialog: String);
-    /// Make use of some warning the ndoe has sent.
+    /// Make use of some warning the node has sent.
     fn handle_warning(&self, warning: Warning);
     /// Handle a change in the node's state.
     fn handle_state_changed(&self, state: NodeState);


### PR DESCRIPTION
I took a first pass at revealing indexes as we apply blocks. I wasn't able to use the simple `keychains` since it uses a borrow of the `KeychainTxOutIndex` and I already have a mutable borrow out to `reveal_next_spk`. Looks a little strange and I don't think this is the right approach.