### PR TITLE
use whole recent history

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ where
                 }
                 NodeMessage::Synced(SyncUpdate {
                     tip,
-                    recent_history: _,
+                    recent_history,
                 }) => {
                     if chain_changeset.is_empty()
                         && self.chain.tip().height() == tip.height
@@ -96,7 +96,9 @@ where
                         // return early if we're already synced
                         return None;
                     }
-                    chain_changeset.insert(tip.height, Some(tip.hash));
+                    recent_history.into_iter().for_each(|(height, header)| {
+                        chain_changeset.insert(height, Some(header.block_hash()));
+                    });
                     break;
                 }
                 _ => (),


### PR DESCRIPTION
I rebased the test branch and was getting an error when trying to merge the chain after a reorg but this solves it. I think adding all the recent blocks to the `LocalChain` should be the de facto anyway. 