### PR TITLE
move logger to call site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bdk_chain = { version = "0.18.0" }
-kyoto-cbf = { version = "0.1.0" }
+kyoto-cbf = { git = "https://github.com/rustaceanrob/kyoto", rev = "4d5043478cec081eca6627ff37cd53dc857b6c20" }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 

--- a/examples/signet.rs
+++ b/examples/signet.rs
@@ -67,7 +67,6 @@ async fn main() -> anyhow::Result<()> {
         .build_node()
         .unwrap();
     let mut client = Client::from_index(chain.tip(), &graph.index, client).unwrap();
-    client.set_logger(Arc::new(PrintLogger::new()));
 
     // Run the node
     if !node.is_running() {
@@ -75,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Sync and apply updates
-    if let Some(update) = client.update().await {
+    if let Some(update) = client.update(Some(Arc::new(PrintLogger::new()))).await {
         let _ = chain.apply_update(update.chain_update.unwrap())?;
         let mut indexed_tx_graph_changeset = graph.apply_update(update.tx_update);
         let index_changeset = graph

--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -37,7 +37,6 @@ async fn main() -> anyhow::Result<()> {
     let (mut node, mut client) = LightClientBuilder::new(&wallet)
         .scan_after(170_000)
         .peers(peers)
-        .logger(Arc::new(TraceLogger::new()))
         .build()
         .unwrap();
 
@@ -51,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
     // Sync and apply updates. We can do this a continual loop while the "application" is running.
     // Often this loop would be on a separate "Task" in a Swift app for instance
     loop {
-        if let Some(update) = client.update().await {
+        if let Some(update) = client.update(Some(Arc::new(TraceLogger::new()))).await {
             wallet.apply_update(update)?;
             // Do something here to add more scripts?
             tracing::info!("Tx count: {}", wallet.transactions().count());


### PR DESCRIPTION
in working on the `BDKSwiftExampleWallet` it makes more sense for the caller of `update` to determine how they would like to handle logs, and not necessarily the initializer 