### PR TITLE
fix(client): used owned transaction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,14 +264,10 @@ where
     }
 
     /// Broadcast a [`Transaction`] with a [`TxBroadcastPolicy`] strategy.
-    pub async fn broadcast(
-        &self,
-        tx: &Transaction,
-        policy: TxBroadcastPolicy,
-    ) -> Result<(), Error> {
+    pub async fn broadcast(&self, tx: Transaction, policy: TxBroadcastPolicy) -> Result<(), Error> {
         self.sender
             .broadcast_tx(TxBroadcast {
-                tx: tx.clone(),
+                tx,
                 broadcast_policy: policy,
             })
             .await


### PR DESCRIPTION
it feels like if a user is broadcasting a transaction, they are likely done with it. if they still need the transaction after broadcast, i feel like that `clone` should be moved to the callsite? @ValuedMammal 