### PR TITLE
feat(builder): use wallet lookahead for recovery

### DIFF
--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -30,12 +30,14 @@ async fn main() -> anyhow::Result<()> {
 
     let mut wallet = Wallet::create(desc, change_desc)
         .network(Network::Signet)
+        .lookahead(30)
         .create_wallet_no_persist()?;
 
     // The light client builder handles the logic of inserting the SPKs
     let (node, mut client) = LightClientBuilder::new(&wallet)
         .scan_after(170_000)
         .peers(peers)
+        .use_lookahead_scripts()
         .build()
         .unwrap();
 


### PR DESCRIPTION
i think this should resolve the recovery issue. developers should be specifying the lookahead if more than 25 scripts were used per keychain, so we just take that lookahead here.

cc @ValuedMammal 