### PR TITLE
fix: add feature for `rusqlite` in `kyoto`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 bdk_chain = { version = "0.19.0" }
-kyoto-cbf = { version = "0.2.0" }
+kyoto-cbf = { version = "0.2.0", default-features = false, features = ["dns"] }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 
@@ -15,9 +15,10 @@ version = "1.0.0-beta.4"
 optional = true
 
 [features]
-default = ["trace", "wallet"]
+default = ["trace", "wallet", "rusqlite"]
 trace = ["tracing", "tracing-subscriber"]
 wallet = ["bdk_wallet"]
+rusqlite = ["kyoto-cbf/database"]
 
 [dev-dependencies]
 tokio = { version = "1.37", features = ["full"], default-features = false }
@@ -30,7 +31,8 @@ tracing-subscriber = { version = "0.3" }
 
 [[example]]
 name = "signet"
+required-features = ["rusqlite"]
 
 [[example]]
 name = "wallet"
-required-features = ["wallet", "trace"]
+required-features = ["wallet", "trace", "rusqlite"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,15 +142,15 @@ use kyoto::{IndexedBlock, SyncUpdate, TxBroadcast};
 
 use crate::logger::NodeMessageHandler;
 
-#[cfg(feature = "wallet")]
+#[cfg(all(feature = "wallet", feature = "rusqlite"))]
 pub mod builder;
 pub mod logger;
 
 pub use bdk_chain::local_chain::MissingGenesisError;
 pub use kyoto::{
-    ClientError, DatabaseError, HeaderCheckpoint, Node, NodeBuilder, NodeMessage, NodeState,
-    Receiver, ScriptBuf, ServiceFlags, Transaction, TrustedPeer, TxBroadcastPolicy, Txid, Warning,
-    MAINNET_HEADER_CP, SIGNET_HEADER_CP,
+    ClientError, HeaderCheckpoint, Node, NodeBuilder, NodeMessage, NodeState, Receiver, ScriptBuf,
+    ServiceFlags, Transaction, TrustedPeer, TxBroadcastPolicy, Txid, Warning, MAINNET_HEADER_CP,
+    SIGNET_HEADER_CP,
 };
 
 /// A compact block filter client.


### PR DESCRIPTION
i was going to mess around with integrating `bdk_kyoto` into `ldk-node` and ran into an issue where two different `sqlite` libraries were being built. the `rusqlite` dependency in `kyoto` is not strictly necessary so i make it an optional dependency here