### PR TITLE
Always use lookahead in builder

### DIFF
--- a/examples/wallet.rs
+++ b/examples/wallet.rs
@@ -34,7 +34,6 @@ async fn main() -> anyhow::Result<()> {
     let (node, mut client) = LightClientBuilder::new(&wallet)
         .scan_after(170_000)
         .peers(peers)
-        .use_lookahead_scripts()
         .build()
         .unwrap();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -58,7 +58,6 @@ use kyoto::{
 
 use crate::Client;
 
-const PEEK_INDEX: u32 = 20;
 const RECOMMENDED_PEERS: u8 = 2;
 
 #[derive(Debug)]
@@ -70,7 +69,6 @@ pub struct LightClientBuilder<'a> {
     birthday_height: Option<u32>,
     data_dir: Option<PathBuf>,
     timeout: Option<Duration>,
-    lookahead: bool,
 }
 
 impl<'a> LightClientBuilder<'a> {
@@ -83,7 +81,6 @@ impl<'a> LightClientBuilder<'a> {
             birthday_height: None,
             data_dir: None,
             timeout: None,
-            lookahead: false,
         }
     }
     /// Add peers to connect to over the P2P network.
@@ -109,15 +106,6 @@ impl<'a> LightClientBuilder<'a> {
     /// height provided, this height will be ignored.
     pub fn scan_after(mut self, height: u32) -> Self {
         self.birthday_height = Some(height);
-        self
-    }
-
-    /// Use all the scripts up to the wallet's lookahead parameter. Only to be used during wallet
-    /// recovery, when we do not have any knowledge of the scripts used in the wallet yet. For
-    /// more information on the wallet lookahead,
-    /// see [`KeychainTxOutIndex`](bdk_wallet::chain::indexer::keychain_txout::KeychainTxOutIndex).
-    pub fn use_lookahead_scripts(mut self) -> Self {
-        self.lookahead = true;
         self
     }
 
@@ -215,11 +203,7 @@ impl<'a> LightClientBuilder<'a> {
                 .spk_index()
                 .last_revealed_index(keychain)
                 .unwrap_or(0);
-            let lookahead_index = if self.lookahead {
-                last_revealed + self.wallet.spk_index().lookahead()
-            } else {
-                last_revealed + PEEK_INDEX
-            };
+            let lookahead_index = last_revealed + self.wallet.spk_index().lookahead();
             for index in 0..=lookahead_index {
                 spks.insert(self.wallet.peek_address(keychain, index).script_pubkey());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,11 @@ where
 
     /// Add more scripts to the node. For example, a user may reveal a Bitcoin address to receive a
     /// payment, so this script should be added to the [`Node`].
+    ///
+    /// ## Note
+    ///
+    /// When using the [`LightClientBuidler`](crate::builder), the wallet lookahead will be used
+    /// to peek ahead and scan for additional scripts.
     pub async fn add_script(&self, script: impl Into<ScriptBuf>) -> Result<(), ClientError> {
         self.client.add_script(script).await
     }


### PR DESCRIPTION
I think the `PEEK_INDEX` constant was a relic of when I did not know the `Wallet` already has a lookahead via `KeychainTxOutIndex`. I think its better to assume we will always want to peek in advance whatever the user defined for their `Wallet` lookahead