### PR TITLE
lib: upgrade `kyoto` to `0.3.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.63.0"
 
 [dependencies]
 bdk_chain = { version = "0.20.0" }
-kyoto-cbf = { version = "0.2.0", default-features = false, features = ["dns"] }
+kyoto-cbf = { version = "0.3.0", default-features = false, features = ["dns"] }
 tracing = { version = "0.1", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -53,7 +53,9 @@ use kyoto::{
     chain::checkpoints::{
         HeaderCheckpoint, MAINNET_HEADER_CP, REGTEST_HEADER_CP, SIGNET_HEADER_CP,
     },
-    BlockHash, DatabaseError, Network, Node, NodeBuilder, ScriptBuf, TrustedPeer,
+    core::builder::NodeDefault,
+    db::error::SqlInitializationError,
+    BlockHash, Network, NodeBuilder, ScriptBuf, TrustedPeer,
 };
 
 use crate::Client;
@@ -154,7 +156,7 @@ impl<'a> LightClientBuilder<'a> {
     }
 
     /// Build a light client node and a client to interact with the node.
-    pub fn build(self) -> Result<(Node, Client<KeychainKind>), BuilderError> {
+    pub fn build(self) -> Result<(NodeDefault, Client<KeychainKind>), BuilderError> {
         let network = self.wallet.network();
         let mut node_builder = NodeBuilder::new(network);
         if let Some(whitelist) = self.peers {
@@ -218,13 +220,13 @@ impl<'a> LightClientBuilder<'a> {
     }
 }
 
-/// Errors thrown by a client.
+/// Errors thrown by the [`LightClientBuilder`].
 #[derive(Debug)]
 pub enum BuilderError {
     /// The `LocalChain` was not initialized with a genesis block.
     Chain(MissingGenesisError),
     /// The database encountered a fatal error.
-    Database(DatabaseError),
+    Database(SqlInitializationError),
 }
 
 impl std::fmt::Display for BuilderError {
@@ -251,8 +253,8 @@ impl From<MissingGenesisError> for BuilderError {
     }
 }
 
-impl From<DatabaseError> for BuilderError {
-    fn from(value: DatabaseError) -> Self {
+impl From<SqlInitializationError> for BuilderError {
+    fn from(value: SqlInitializationError) -> Self {
         BuilderError::Database(value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,8 @@ pub mod builder;
 pub mod logger;
 
 pub use bdk_chain::local_chain::MissingGenesisError;
+#[cfg(feature = "rusqlite")]
+pub use kyoto::core::builder::NodeDefault;
 pub use kyoto::{
     ClientError, HeaderCheckpoint, Node, NodeBuilder, NodeMessage, NodeState, Receiver, ScriptBuf,
     ServiceFlags, Transaction, TrustedPeer, TxBroadcastPolicy, Txid, Warning, MAINNET_HEADER_CP,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -6,6 +6,7 @@ use tokio::time;
 
 use bdk_kyoto::builder::LightClientBuilder;
 use bdk_kyoto::logger::PrintLogger;
+use bdk_kyoto::NodeDefault;
 use bdk_kyoto::TrustedPeer;
 use bdk_testenv::bitcoincore_rpc::RpcApi;
 use bdk_testenv::bitcoind;
@@ -41,7 +42,7 @@ async fn wait_for_height(env: &TestEnv, height: u32) -> anyhow::Result<()> {
 fn init_node(
     env: &TestEnv,
     wallet: &bdk_wallet::Wallet,
-) -> anyhow::Result<(bdk_kyoto::Node, bdk_kyoto::Client<KeychainKind>)> {
+) -> anyhow::Result<(NodeDefault, bdk_kyoto::Client<KeychainKind>)> {
     let peer = env.bitcoind.params.p2p_socket.unwrap();
     let ip: IpAddr = (*peer.ip()).into();
     let port = peer.port();


### PR DESCRIPTION
fast turnaround from `0.2.0` to `0.3.0` to get ready for TABconf and library release